### PR TITLE
changed host link due to domain change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AyuGram Sync Server Frontend
 
-It's hosted [here](https://ayusync.radolyn.com/ui).
+It's hosted [here](https://ayusync.cloud/ui).
 
 ## Setup
 


### PR DESCRIPTION
ayusync.radolyn.com doesn't work anymore, it was moved to ayusync.cloud instead